### PR TITLE
TCA-50 The lintOption was implemented

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,9 @@ android {
     buildFeatures {
         viewBinding = true
     }
+    lintOptions {
+        disable 'NullSafeMutableLiveData'
+    }
 }
 
 dependencies {

--- a/app/src/main/java/ar/scacchipa/twittercloneapp/presentation/login/LoginWebSectionViewModel.kt
+++ b/app/src/main/java/ar/scacchipa/twittercloneapp/presentation/login/LoginWebSectionViewModel.kt
@@ -17,8 +17,8 @@ class LoginWebSectionViewModel (
     private val authorizationUseCase: AuthorizationUseCase
 ): ViewModel() {
 
-    private val _responseDomain = MutableLiveData<ResponseDomain?>()
-    val responseDomain: LiveData<ResponseDomain?> = _responseDomain
+    private val _responseDomain = MutableLiveData<ResponseDomain>()
+    val responseDomain: LiveData<ResponseDomain> = _responseDomain
 
     fun onReceiveUrl(uri: URI) {
         if (uri.host == URI(Constants.REDIRECT_URI).host) {


### PR DESCRIPTION
MutableLiveData with nullable type error.

     private val _responseDomain = MutableLiveData<ResponseDomain>()
    val responseDomain: LiveData<ResponseDomain> = _responseDomain


    private fun getCredential(
        transitoryCode: String
    ) {
        viewModelScope.launch {
            _responseDomain.value = authorizationUseCase( // show false error
                transitoryToken = transitoryCode
            )
        }
    }